### PR TITLE
Add `JSScheduler` and `JSPromise` publisher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  linux_build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: swiftwasm/swiftwasm-action@master
+        with:
+          shell-action: swift build --triple wasm32-unknown-wasi

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,28 @@
+name: Check PR labels
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the `main` branch
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  check-labels:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Match PR Label
+        uses: zwaldowski/match-label-action@v2
+        with:
+          allowed_multiple: >
+            API design,
+            bug,
+            continuous integration,
+            dependencies,
+            documentation,
+            enhancement,
+            refactor,
+            test suite,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: detect-private-key
+    -   id: check-merge-conflict
+-   repo: https://github.com/hodovani/pre-commit-swift
+    rev: master
+    hooks:
+    -   id: swift-lint
+    -   id: swift-format

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,12 @@
+--indent 2
+--indentcase false
+--trimwhitespace always
+--voidtype tuple
+--nospaceoperators ..<,...
+--ifdef noindent
+--stripunusedargs closure-only
+--maxwidth 100
+--wraparguments before-first
+--funcattributes prev-line
+--disable andOperator
+--swiftversion 5.3

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,19 @@
+disabled_rules:
+  - trailing_comma
+  - identifier_name
+  - void_return
+  - operator_whitespace
+  - nesting
+  - cyclomatic_complexity
+  - multiple_closures_with_trailing_closure
+  - type_name
+  - opening_brace
+
+line_length: 100
+
+function_body_length:
+  - 50
+
+included:
+  - Sources
+  - Tests

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
+  "licenser.author": "OpenCombineJS contributors"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "carton dev",
+      "type": "shell",
+      "command": "carton dev"
+    }
+  ]
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,34 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "JavaScriptKit",
+        "repositoryURL": "https://github.com/swiftwasm/JavaScriptKit.git",
+        "state": {
+          "branch": null,
+          "revision": "6e84a7003071ed3e9fa7f8d8266a272a36b84608",
+          "version": "0.7.2"
+        }
+      },
+      {
+        "package": "OpenCombine",
+        "repositoryURL": "https://github.com/MaxDesiatov/OpenCombine.git",
+        "state": {
+          "branch": null,
+          "revision": "29ab27e488a1c9afef217b1435b3293d4a77b1ae",
+          "version": "0.0.1"
+        }
+      },
+      {
+        "package": "Runtime",
+        "repositoryURL": "https://github.com/MaxDesiatov/Runtime.git",
+        "state": {
+          "branch": null,
+          "revision": "a617ead8a125a97e69d6100e4d27922006e82e0a",
+          "version": "2.1.2"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:5.3
+import PackageDescription
+let package = Package(
+  name: "OpenCombineJS",
+  products: [
+    .executable(name: "OpenCombineJSExample", targets: ["OpenCombineJSExample"]),
+    .library(name: "OpenCombineJS", targets: ["OpenCombineJS"]),
+  ],
+  dependencies: [
+    .package(
+      name: "JavaScriptKit",
+      url: "https://github.com/swiftwasm/JavaScriptKit.git",
+      from: "0.7.2"
+    ),
+    .package(
+      name: "OpenCombine",
+      url: "https://github.com/MaxDesiatov/OpenCombine.git",
+      from: "0.0.1"
+    ),
+  ],
+  targets: [
+    .target(
+      name: "OpenCombineJSExample",
+      dependencies: [
+        "OpenCombineJS",
+      ]
+    ),
+    .target(
+      name: "OpenCombineJS",
+      dependencies: [
+        "JavaScriptKit", "OpenCombine",
+      ]
+    ),
+  ]
+)

--- a/Sources/OpenCombineJS/JSError.swift
+++ b/Sources/OpenCombineJS/JSError.swift
@@ -1,0 +1,22 @@
+// Copyright 2020 OpenCombineJS contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import JavaScriptKit
+
+extension JSError: JSValueConstructible {
+  public static func construct(from value: JSValue) -> JSError? {
+    guard let object = value.object else { return nil }
+    return JSError(unsafelyWrapping: object)
+  }
+}

--- a/Sources/OpenCombineJS/JSPromise.swift
+++ b/Sources/OpenCombineJS/JSPromise.swift
@@ -1,0 +1,86 @@
+// Copyright 2020 OpenCombineJS contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import JavaScriptKit
+import OpenCombine
+
+extension JSPromise where Success: JSValueConstructible, Failure: JSError {
+  public final class PromisePublisher: Publisher {
+    public typealias Output = Success
+
+    /// Reference to a parent promise instance to prevent early deallocation
+    private var parent: JSPromise?
+
+    /// Reference to a `then` success callback promise instance to prevent early deallocation
+    private var then: JSPromise<JSValue, Failure>?
+
+    /// `Future` instance that handles subscriptions to this publisher.
+    private var future: Future<Success, Failure>?
+
+    fileprivate init(parent: JSPromise) {
+      future = .init { resolver in
+        let then = parent.then { value -> JSValue in
+          resolver(.success(value))
+          return .undefined
+        }
+
+        then.catch {
+          resolver(.failure($0))
+        }
+        self.then = then
+      }
+      self.parent = parent
+    }
+
+    public func receive<Downstream: Subscriber>(subscriber: Downstream)
+      where Success == Downstream.Input, Failure == Downstream.Failure
+    {
+      guard let parent = parent, let then = then, let future = future else { return }
+
+      future.receive(subscriber: WrappingSubscriber(inner: subscriber, parent: parent, then: then))
+    }
+  }
+
+  /// Creates a new publisher for this `JSPromise` instance.
+  public var publisher: PromisePublisher {
+    .init(parent: self)
+  }
+
+  /** Helper type that wraps a given `inner` subscriber and holds references to both stored promises
+   of `PromisePublisher`, as `PromisePublisher` itself can be deallocated earlier than its
+   subscribers.
+   */
+  private struct WrappingSubscriber<Inner: Subscriber>: Subscriber {
+    typealias Input = Inner.Input
+    typealias Failure = Inner.Failure
+
+    let inner: Inner
+    let parent: JSPromise
+    let then: JSPromise<JSValue, Failure>
+
+    var combineIdentifier: CombineIdentifier { inner.combineIdentifier }
+
+    func receive(subscription: Subscription) {
+      inner.receive(subscription: subscription)
+    }
+
+    func receive(_ input: Input) -> Subscribers.Demand {
+      inner.receive(input)
+    }
+
+    func receive(completion: Subscribers.Completion<Failure>) {
+      inner.receive(completion: completion)
+    }
+  }
+}

--- a/Sources/OpenCombineJS/JSPromise.swift
+++ b/Sources/OpenCombineJS/JSPromise.swift
@@ -29,7 +29,7 @@ extension JSPromise where Success: JSValueConstructible, Failure: JSError {
     private var future: Future<Success, Failure>?
 
     fileprivate init(parent: JSPromise) {
-      future = .init { resolver in
+      future = .init { [weak self] resolver in
         let then = parent.then { value -> JSValue in
           resolver(.success(value))
           return .undefined
@@ -38,7 +38,7 @@ extension JSPromise where Success: JSValueConstructible, Failure: JSError {
         then.catch {
           resolver(.failure($0))
         }
-        self.then = then
+        self?.then = then
       }
       self.parent = parent
     }

--- a/Sources/OpenCombineJS/JSScheduler.swift
+++ b/Sources/OpenCombineJS/JSScheduler.swift
@@ -1,0 +1,176 @@
+// Copyright 2020 OpenCombineJS contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import JavaScriptKit
+import OpenCombine
+
+public final class JSScheduler: Scheduler {
+  private final class CancellableTimer: Cancellable {
+    let cancellation: () -> ()
+
+    init(_ cancellation: @escaping () -> ()) {
+      self.cancellation = cancellation
+    }
+
+    func cancel() {
+      cancellation()
+    }
+  }
+
+  public struct SchedulerTimeType: Strideable {
+    let millisecondsValue: Double
+
+    public func advanced(by n: Stride) -> Self {
+      .init(millisecondsValue: millisecondsValue + n.magnitude)
+    }
+
+    public func distance(to other: Self) -> Stride {
+      .init(millisecondsValue: other.millisecondsValue - millisecondsValue)
+    }
+
+    public struct Stride: SchedulerTimeIntervalConvertible, Comparable, SignedNumeric {
+      /// Time interval magnitude in milliseconds
+      public var magnitude: Double
+
+      public init?<T>(exactly source: T) where T: BinaryInteger {
+        guard let magnitude = Double(exactly: source) else { return nil }
+        self.magnitude = magnitude
+      }
+
+      public init(millisecondsValue: Double) {
+        magnitude = millisecondsValue
+      }
+
+      public init(floatLiteral value: Double) {
+        self = .seconds(value)
+      }
+
+      public init(integerLiteral value: Int) {
+        self = .seconds(value)
+      }
+
+      public static func microseconds(_ us: Int) -> Self {
+        .init(millisecondsValue: 1.0 / (Double(us) * 1000))
+      }
+
+      public static func milliseconds(_ ms: Int) -> Self {
+        .init(millisecondsValue: Double(ms))
+      }
+
+      public static func nanoseconds(_ ns: Int) -> Self {
+        .init(millisecondsValue: 1.0 / (Double(ns) * 1_000_000))
+      }
+
+      public static func seconds(_ s: Double) -> Self {
+        .init(millisecondsValue: s * 1000)
+      }
+
+      public static func seconds(_ s: Int) -> Self {
+        .init(millisecondsValue: Double(s) * 1000)
+      }
+
+      public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.magnitude < rhs.magnitude
+      }
+
+      public static func * (lhs: Self, rhs: Self) -> Self {
+        .init(millisecondsValue: lhs.magnitude * rhs.magnitude)
+      }
+
+      public static func + (lhs: Self, rhs: Self) -> Self {
+        .init(millisecondsValue: lhs.magnitude + rhs.magnitude)
+      }
+
+      public static func - (lhs: Self, rhs: Self) -> Self {
+        .init(millisecondsValue: lhs.magnitude - rhs.magnitude)
+      }
+
+      public static func -= (lhs: inout Self, rhs: Self) {
+        lhs.magnitude -= rhs.magnitude
+      }
+
+      public static func *= (lhs: inout Self, rhs: Self) {
+        lhs.magnitude *= rhs.magnitude
+      }
+
+      public static func += (lhs: inout Self, rhs: Self) {
+        lhs.magnitude += rhs.magnitude
+      }
+    }
+  }
+
+  public struct SchedulerOptions {}
+
+  public var now: SchedulerTimeType { .init(millisecondsValue: JSDate.now()) }
+
+  public var minimumTolerance: SchedulerTimeType.Stride {
+    .init(millisecondsValue: .leastNonzeroMagnitude)
+  }
+
+  private var scheduledTimers = [ObjectIdentifier: JSTimer]()
+
+  public func schedule(options: SchedulerOptions?, _ action: @escaping () -> ()) {
+    var timer: JSTimer!
+    timer = .init(millisecondsDelay: 0) { [weak self, weak timer] in
+      action()
+      if let timer = timer {
+        self?.scheduledTimers[ObjectIdentifier(timer)] = nil
+      }
+    }
+    scheduledTimers[ObjectIdentifier(timer)] = timer
+  }
+
+  public func schedule(
+    after date: SchedulerTimeType,
+    tolerance: SchedulerTimeType.Stride,
+    options: SchedulerOptions?,
+    _ action: @escaping () -> ()
+  ) {
+    var timer: JSTimer!
+    timer = .init(
+      millisecondsDelay: date.millisecondsValue - JSDate.now()
+    ) { [weak self, weak timer] in
+      action()
+      if let timer = timer {
+        self?.scheduledTimers[ObjectIdentifier(timer)] = nil
+      }
+    }
+    scheduledTimers[ObjectIdentifier(timer)] = timer
+  }
+
+  public func schedule(
+    after date: SchedulerTimeType,
+    interval: SchedulerTimeType.Stride,
+    tolerance: SchedulerTimeType.Stride,
+    options: SchedulerOptions?,
+    _ action: @escaping () -> ()
+  ) -> Cancellable {
+    var timeoutTimer, intervalTimer: JSTimer!
+
+    timeoutTimer = .init(
+      millisecondsDelay: date.millisecondsValue - JSDate.now()
+    ) { [weak self, weak timeoutTimer] in
+      intervalTimer = .init(millisecondsDelay: interval.magnitude) { action() }
+
+      self?.scheduledTimers[ObjectIdentifier(intervalTimer)] = intervalTimer
+
+      if let timeoutTimer = timeoutTimer {
+        self?.scheduledTimers[ObjectIdentifier(timeoutTimer)] = nil
+      }
+    }
+    scheduledTimers[ObjectIdentifier(timeoutTimer)] = timeoutTimer
+
+    return CancellableTimer { self.scheduledTimers[ObjectIdentifier(intervalTimer)] = nil }
+  }
+}

--- a/Sources/OpenCombineJS/JSValueDecoder.swift
+++ b/Sources/OpenCombineJS/JSValueDecoder.swift
@@ -1,0 +1,22 @@
+// Copyright 2020 OpenCombineJS contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import JavaScriptKit
+import OpenCombine
+
+extension JSValueDecoder: TopLevelDecoder {
+  public func decode<T: Decodable>(_ type: T.Type, from value: JSValue) throws -> T {
+    try decode(type, from: value)
+  }
+}

--- a/Sources/OpenCombineJSExample/main.swift
+++ b/Sources/OpenCombineJSExample/main.swift
@@ -1,0 +1,34 @@
+import JavaScriptKit
+import OpenCombine
+import OpenCombineJS
+
+private let _jsFetch = JSObject.global.fetch.function!
+func fetch(_ url: String) -> JSPromise<JSObject, JSError> {
+  JSPromise(_jsFetch(url).object!)!
+}
+
+let document = JSObject.global.document.object!
+let p = document.createElement!("p").object!
+_ = document.body.object!.appendChild!(p)
+
+var subscription: AnyCancellable?
+
+let timer = JSTimer(millisecondsDelay: 2000, isRepeating: true) {
+  subscription = fetch("https://httpbin.org/uuid")
+    .publisher
+    .flatMap { (response: JSObject) -> JSPromise<JSValue, JSError>.PromisePublisher in
+      JSPromise<JSValue, JSError>(response.json!().object!)!.publisher
+    }
+    .mapError { $0 as Error }
+    .map { Result<String, Error>.success($0.object!.uuid.string!) }
+    .catch { Just(.failure($0)) }
+    .sink {
+      let time = JSDate().toLocaleTimeString()
+      switch $0 {
+      case let .success(uuid):
+        p.innerText = .string("At \(time) received uuid \(uuid)")
+      case let .failure(error):
+        p.innerText = .string("At \(time) received error \(error)")
+      }
+    }
+}

--- a/Sources/OpenCombineJSExample/main.swift
+++ b/Sources/OpenCombineJSExample/main.swift
@@ -16,8 +16,8 @@ var subscription: AnyCancellable?
 let timer = JSTimer(millisecondsDelay: 2000, isRepeating: true) {
   subscription = fetch("https://httpbin.org/uuid")
     .publisher
-    .flatMap { (response: JSObject) -> JSPromise<JSValue, JSError>.PromisePublisher in
-      JSPromise<JSValue, JSError>(response.json!().object!)!.publisher
+    .flatMap {
+      JSPromise<JSValue, JSError>($0.json!().object!)!.publisher
     }
     .mapError { $0 as Error }
     .map { Result<String, Error>.success($0.object!.uuid.string!) }


### PR DESCRIPTION
`JSScheduler` is copied from https://github.com/TokamakUI/Tokamak/pull/281.

You can see the `JSPromise` publisher in action in combination with `fetch` by running `carton dev` in the root directory. I saw some issues with `JSValueDecoder`, which is why it's not used in this PR. I will investigate `JSValueDecoder` issues separately.